### PR TITLE
fix: Restore ribbon icon order and hidden state after lazy plugin load

### DIFF
--- a/src/features/lazy-engine/lazy-engine-feature.ts
+++ b/src/features/lazy-engine/lazy-engine-feature.ts
@@ -10,6 +10,7 @@ import { LazyCommandRunner } from "src/features/lazy-engine/lazy-runner/lazy-com
 import PQueue from "p-queue";
 import { PLUGIN_MODE } from "src/core/types";
 import type { AppFeature } from "src/core/feature";
+import { patchRibbonReorder } from "src/patches/ribbon-reorder";
 import { patchSetViewState } from "src/patches/view-state";
 import type { CoreContainer } from "src/services/core-container";
 
@@ -54,6 +55,7 @@ export class LazyEngineFeature implements AppFeature {
             register: this.ctx.register.bind(this.ctx),
             onViewType: (viewType: string) => this.viewLoader.checkViewTypeForLazyLoading(viewType),
         });
+        patchRibbonReorder(ctx);
 
         this.viewLoader.registerActiveLeafReload();
         this.fileLoader.register();

--- a/src/patches/ribbon-reorder.test.ts
+++ b/src/patches/ribbon-reorder.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Plugin } from "obsidian";
+import log from "loglevel";
+import { patchRibbonReorder } from "./ribbon-reorder";
+
+describe("patchRibbonReorder", () => {
+    let originalAddRibbonIcon: any;
+    let unregister: () => void;
+
+    beforeEach(() => {
+        vi.resetAllMocks();
+        originalAddRibbonIcon = undefined;
+    });
+
+    afterEach(() => {
+        // Restore prototype if we modified it
+        if (originalAddRibbonIcon !== undefined) {
+            (Plugin.prototype as any).addRibbonIcon = originalAddRibbonIcon;
+        } else {
+            delete (Plugin.prototype as any).addRibbonIcon;
+        }
+    });
+
+    function setupPrototype() {
+        originalAddRibbonIcon = (Plugin.prototype as any).addRibbonIcon;
+        (Plugin.prototype as any).addRibbonIcon = vi.fn().mockReturnValue({ tagName: "DIV" });
+    }
+
+    function createMockCtx(appOverrides: Record<string, any> = {}) {
+        return {
+            app: { updateRibbonDisplay: vi.fn(), ...appOverrides },
+            register: (fn: () => void) => { unregister = fn; },
+        } as any;
+    }
+
+    function createPluginInstance() {
+        const plugin = Object.create(Plugin.prototype);
+        plugin.manifest = { id: "test-plugin" };
+        return plugin;
+    }
+
+    it("calls updateRibbonDisplay when addRibbonIcon is called", () => {
+        setupPrototype();
+        const ctx = createMockCtx();
+        patchRibbonReorder(ctx);
+
+        const plugin = createPluginInstance();
+        plugin.addRibbonIcon("dice", "Test", vi.fn());
+
+        expect(ctx.app.updateRibbonDisplay).toHaveBeenCalled();
+    });
+
+    it("preserves original addRibbonIcon return value", () => {
+        setupPrototype();
+        const expectedEl = { tagName: "SPAN" };
+        (Plugin.prototype as any).addRibbonIcon = vi.fn().mockReturnValue(expectedEl);
+
+        const ctx = createMockCtx();
+        patchRibbonReorder(ctx);
+
+        const plugin = createPluginInstance();
+        const result = plugin.addRibbonIcon("dice", "Test", vi.fn());
+
+        expect(result).toBe(expectedEl);
+    });
+
+    it("no-ops when updateRibbonDisplay is missing", () => {
+        setupPrototype();
+        const ctx = createMockCtx({ updateRibbonDisplay: undefined });
+        delete ctx.app.updateRibbonDisplay;
+        patchRibbonReorder(ctx);
+
+        const plugin = createPluginInstance();
+        expect(() => plugin.addRibbonIcon("dice", "Test", vi.fn())).not.toThrow();
+    });
+
+    it("no-ops when addRibbonIcon is missing on prototype", () => {
+        // Don't add addRibbonIcon to prototype
+        originalAddRibbonIcon = (Plugin.prototype as any).addRibbonIcon;
+        const ctx = createMockCtx();
+        expect(() => patchRibbonReorder(ctx)).not.toThrow();
+    });
+
+    it("isolates updateRibbonDisplay exceptions and logs a warning once", () => {
+        setupPrototype();
+        const expectedEl = { tagName: "DIV" };
+        (Plugin.prototype as any).addRibbonIcon = vi.fn().mockReturnValue(expectedEl);
+
+        const error = new Error("ribbon exploded");
+        const ctx = createMockCtx({
+            updateRibbonDisplay: vi.fn().mockImplementation(() => {
+                throw error;
+            }),
+        });
+        patchRibbonReorder(ctx);
+
+        const logger = log.getLogger("OnDemandPlugin/RibbonReorder");
+        const warnSpy = vi.spyOn(logger, "warn").mockImplementation(() => {});
+        const plugin = createPluginInstance();
+
+        let result: any;
+        expect(() => { result = plugin.addRibbonIcon("dice", "Test", vi.fn()); }).not.toThrow();
+        expect(result).toBe(expectedEl);
+        expect(warnSpy).toHaveBeenCalledWith("updateRibbonDisplay failed:", error);
+
+        // Second call should NOT log again (once-only guard)
+        warnSpy.mockClear();
+        expect(() => plugin.addRibbonIcon("dice", "Test2", vi.fn())).not.toThrow();
+        expect(warnSpy).not.toHaveBeenCalled();
+
+        warnSpy.mockRestore();
+    });
+
+    it("cleanup restores original method", () => {
+        setupPrototype();
+        const original = (Plugin.prototype as any).addRibbonIcon;
+        const ctx = createMockCtx();
+        patchRibbonReorder(ctx);
+
+        // Method should be patched (different from original)
+        expect((Plugin.prototype as any).addRibbonIcon).not.toBe(original);
+
+        // Call unregister to restore
+        unregister();
+
+        expect((Plugin.prototype as any).addRibbonIcon).toBe(original);
+    });
+});

--- a/src/patches/ribbon-reorder.ts
+++ b/src/patches/ribbon-reorder.ts
@@ -1,0 +1,32 @@
+import { Plugin } from "obsidian";
+import { around } from "monkey-around";
+import log from "loglevel";
+import type { PluginContext } from "../core/plugin-context";
+
+const logger = log.getLogger("OnDemandPlugin/RibbonReorder");
+
+export function patchRibbonReorder(ctx: PluginContext): void {
+    if (typeof Plugin.prototype.addRibbonIcon !== "function") return;
+
+    let warned = false;
+
+    ctx.register(
+        around(Plugin.prototype as any, {
+            addRibbonIcon: (next: any) =>
+                function (this: any, ...args: any[]) {
+                    const result = next.call(this, ...args);
+                    try {
+                        if (typeof (ctx.app as any).updateRibbonDisplay === "function") {
+                            (ctx.app as any).updateRibbonDisplay();
+                        }
+                    } catch (e) {
+                        if (!warned) {
+                            logger.warn("updateRibbonDisplay failed:", e);
+                            warned = true;
+                        }
+                    }
+                    return result;
+                },
+        }),
+    );
+}

--- a/src/patches/ribbon-reorder.ts
+++ b/src/patches/ribbon-reorder.ts
@@ -11,13 +11,13 @@ export function patchRibbonReorder(ctx: PluginContext): void {
     let warned = false;
 
     ctx.register(
-        around(Plugin.prototype as any, {
-            addRibbonIcon: (next: any) =>
-                function (this: any, ...args: any[]) {
+        around(Plugin.prototype, {
+            addRibbonIcon: (next) =>
+                function (this: Plugin, ...args: Parameters<Plugin["addRibbonIcon"]>) {
                     const result = next.call(this, ...args);
                     try {
-                        if (typeof (ctx.app as any).updateRibbonDisplay === "function") {
-                            (ctx.app as any).updateRibbonDisplay();
+                        if (typeof ctx.app.updateRibbonDisplay === "function") {
+                            ctx.app.updateRibbonDisplay();
                         }
                     } catch (e) {
                         if (!warned) {


### PR DESCRIPTION
Closes https://github.com/22-2/obsidian-on-demand-plugins/issues/1

## Summary

- Ribbon icons added by lazily-loaded plugins currently appear at the end of the ribbon in their default state, ignoring the user's configured order and hidden/visible settings
- This PR patches `Plugin.prototype.addRibbonIcon` (via `monkey-around`) to call `app.updateRibbonDisplay()` after each icon is added, so the ribbon re-sorts and re-applies hidden state immediately
- The patch is registered in the lazy engine startup alongside the existing view-state patch

## Changes

- **`src/patches/ribbon-reorder.ts`** — New patch that wraps `addRibbonIcon` to trigger `updateRibbonDisplay()` after each call, with a guard for missing API and a warn-once error handler
- **`src/patches/ribbon-reorder.test.ts`** — 6 unit tests covering: reorder on add, no-op when API is missing, error suppression, prototype guard, and unregister cleanup
- **`src/features/lazy-engine/lazy-engine-feature.ts`** — Registers the new patch during lazy engine startup

## Test plan

- [x] All 64 existing tests pass (8 test files)
- [x] 6 new tests for the ribbon reorder patch pass
- [ ] Manual: Enable a plugin that adds a ribbon icon, configure a custom ribbon order, restart Obsidian, verify the icon appears in the correct position after lazy load

🤖 Generated with [Claude Code](https://claude.com/claude-code)